### PR TITLE
Fix CI Python version

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9", "3.10", "3.11.0-alpha.1"]
+        python-version: ["3.6","3.7","3.8","3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9", "3.10", "3.11"]
+        python-version: ["3.6","3.7","3.8","3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Estaba teniendo problemas con la versión 11 de Python en la CI como se reportaba en #60 

Tras investigar en las [versiones existentes en las github actions de Python](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) me he dado cuenta que aún no hay una versión calificada como estable por lo que he decicdo eliminar esta versión por ahora. No me interesan para este trabajo las versiones en fase de testeo.

closes #60 